### PR TITLE
Add INSTALLDIR parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 *.i*86
 *.x86_64
 *.hex
+eflomal
 
 # Debug files
 *.dSYM/

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CFLAGS=-Ofast -march=native -Wall --std=gnu99 -Wno-unused-function -g -fopenmp
 # This is more suitable for debugging:
 #CFLAGS=-Og -Wall --std=gnu99 -Wno-unused-function -g -fopenmp
 LDFLAGS=-lm -lrt -lgomp -fopenmp
+INSTALLDIR=/usr/local/bin
 
 all: eflomal
 
@@ -11,7 +12,7 @@ eflomal.o: eflomal.c natmap.c hash.c random.c simd_math_prims.h
 eflomal: eflomal.o
 
 install: eflomal
-	install -t /usr/local/bin eflomal
+	install -t $(INSTALLDIR) eflomal
 
 clean:
 	rm -f eflomal eflomal.o

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ To compile and install the C binary and the Python bindings:
     sudo make install
     python3 setup.py install
 
-edit `Makefile` manually if you want to install somewhere other than the
-default `/usr/local/bin`. Note that the `align.py` script now uses the
-`eflomal` executable in the same directory as `align.py`, rather than in
-`$PATH`.
+Change the `INSTALLDIR` parameter in the install step if you want to install somewhere
+other than the default `/usr/local/bin` (e.g. `make install -e INSTALLDIR=~/bin`).
+Note that the `align.py` script now uses the `eflomal` executable in the same directory
+as `align.py`, rather than in `$PATH`.
 
 
 ## Using


### PR DESCRIPTION
Because of automation (incorporation in other projects), editing the `Makefile` to change the installation directory is undesirable. This PR adds an `INSTALLDIR` parameter to `Makefile`, which defaults to `/usr/local/bin`, but can be easily changed by e.g. `make install -e INSTALLDIR=~/bin`.

I also edited `.gitignore`, since the `eflomal` binary was not listed there and is created every time it is build (similarly to object files).