### PR TITLE
Bump version to 2.0.0 and update pipelines to use trusted publishing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - os: ubuntu-20.04
             python-version: "3.6"
@@ -16,9 +16,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -40,12 +40,12 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -57,7 +57,7 @@ jobs:
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -50,6 +50,10 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
+    environment: pypi
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     needs: [build_sdist]
     runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'v'
@@ -64,7 +68,7 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          # To test: repository_url: https://test.pypi.org/legacy/
+      - uses: pypa/gh-action-pypi-publish@v1.9.0
+        #with:
+        #  password: ${{ secrets.PYPI_API_TOKEN }}
+        # To test: repository_url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -83,14 +83,16 @@ has not been tested yet.
 
 ## Generating priors
 
-If you have a large file that you want to use as "training data", `en-sv`, and
-a small file  that you later want to align quickly, `en-sv.small`, start by
-aligning the large file as usual, e.g.:
+If you have a large file that you want to use as "training data", named `en-sv`,
+and a small file that you later want to align quickly, `en-sv.small`, start by
+aligning the large file as usual, specifying where to write the reverse and forward
+alignment output files:
 
     eflomal-align -i en-sv --model 3 -f en-sv.fwd -r en-sv.rev
 
-Now you can generate priors based on this large aligned file, stored in
-`en-sv.priors`:
+The above command will give you two intermediate files `en-sv.fwd` and `en-sv.rev`.
+Now you can use these to generate priors based on the large aligned file. The
+priors will be stored in `en-sv.priors`:
 
     eflomal-makepriors -i en-sv -f en-sv.fwd -r en-sv.rev --priors en-sv.priors
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ tests_require = ['pytest']
 
 setup(
     name='eflomal',
-    version='1.0.0-beta2',
+    version='2.0.0',
     author='Robert Östling',
     url='https://github.com/robertostling/eflomal',
     license='GNU GPLv3',


### PR DESCRIPTION
There was a request to tag a non-beta version for the [Python packaging](https://github.com/robertostling/eflomal/pull/17) changes, which were first tagged as a pre-release of 1.0.0. I noticed only now that version v1.0.0 had actually been tagged much earlier, so the new version should be v2.0.0 due to the backward-incompatible changes.

I already published the 2.0.0 release to PyPI from the Helsinki-NLP fork, so the PR is just to keep this repository in sync.

I also included the commit to the documentation from https://github.com/robertostling/eflomal/pull/19 in the 2.0.0 release, so it's enough to merge this PR.
